### PR TITLE
nearly python3 friendly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ or
 
 ``python setup.py install --prefix=/some/directory/``
 
+NOTE: at the moment, apogee only supports python2 due to the `esutil` dependency.
+
 Installing FERRE
 ^^^^^^^^^^^^^^^^^
 
@@ -117,6 +119,10 @@ VARIABLES**)
 * **SDSS_LOCAL_SAS_MIRROR**: top-level directory that will be used to (selectively) mirror the SDSS SAS
 * **RESULTS_VERS**: APOGEE reduction version (e.g., v304 for DR10, v402 for DR11, v603 for DR12, l30e.2 for DR13)
 * **APOGEE_APOKASC_REDUX**: APOKASC catalog version (e.g., v6.2a)
+
+In order to use this code, you will need to set these environment variables
+on your machine with commands like `export SDSS_LOCAL_SAS_MIRROR="/desired/path/to/SDSS/data"`
+which can be saved in `~/.bashrc` or a similar file.
 
 **NEW**: Data files mirror the SDSS SAS as much as possible
 (previously, many data files lived in the $SDSS_LOCAL_SAS_MIRROR

--- a/apogee/samples/check_rc_against_apokasc.py
+++ b/apogee/samples/check_rc_against_apokasc.py
@@ -20,7 +20,7 @@ def match_apokasc_rc(rcfile=None,addl_logg_cut=False):
         rcdata= fitsio.read(rcfile)
     if addl_logg_cut:
         rcdata= rcdata[rcdata['ADDL_LOGG_CUT'] == 1]
-    print "RC catalog has %i entries ..." % len(rcdata)
+    print("RC catalog has %i entries ..." % len(rcdata))
     #Match
     h=esutil.htm.HTM()
     m1,m2,d12 = h.match(kascdata['RA'],kascdata['DEC'],
@@ -46,10 +46,10 @@ if __name__ == '__main__':
     rcclumpseismo= clumpseismo*(data['RC'] == 1)#*(((data['TEFF']-4800.)/1000.+2.75) > data['LOGG'])
     rcnoclumpseismo= noclumpseismo*(data['RC'] == 1)#*(((data['TEFF']-4800.)/1000.+2.75) > data['LOGG'])
     #Statistics using evolutionary state measurements
-    print "%i APOKASC stars have evolutionary state measurements" % (numpy.sum(clumpseismo)+numpy.sum(noclumpseismo))
-    print "%i APOKASC RC stars have evolutionary state measurements" % (numpy.sum(rcclumpseismo)+numpy.sum(rcnoclumpseismo))
-    print "%i / %i = %i%% APOKASC CLUMP stars are in the RC catalog (COMPLETENESS)" % (numpy.sum(rcclumpseismo),numpy.sum(clumpseismo),float(numpy.sum(rcclumpseismo))/numpy.sum(clumpseismo)*100.)
-    print "%i / %i = %i%% APOKASC non-CLUMP stars out of all stars in the RC catalog with evolutionary measurements are in the RC catalog (CONTAMINATION)" % (numpy.sum(rcnoclumpseismo),numpy.sum(rcnoclumpseismo)+numpy.sum(rcclumpseismo),float(numpy.sum(rcnoclumpseismo))/(numpy.sum(rcnoclumpseismo)+numpy.sum(rcclumpseismo))*100.)
+    print("%i APOKASC stars have evolutionary state measurements" % (numpy.sum(clumpseismo)+numpy.sum(noclumpseismo)))
+    print("%i APOKASC RC stars have evolutionary state measurements" % (numpy.sum(rcclumpseismo)+numpy.sum(rcnoclumpseismo)))
+    print("%i / %i = %i%% APOKASC CLUMP stars are in the RC catalog (COMPLETENESS)" % (numpy.sum(rcclumpseismo),numpy.sum(clumpseismo),float(numpy.sum(rcclumpseismo))/numpy.sum(clumpseismo)*100.))
+    print("%i / %i = %i%% APOKASC non-CLUMP stars out of all stars in the RC catalog with evolutionary measurements are in the RC catalog (CONTAMINATION)" % (numpy.sum(rcnoclumpseismo),numpy.sum(rcnoclumpseismo)+numpy.sum(rcclumpseismo),float(numpy.sum(rcnoclumpseismo))/(numpy.sum(rcnoclumpseismo)+numpy.sum(rcclumpseismo))*100.))
     rcindx= data['RC'] == 1
     #Statistics using simple seismo logg cut
     kascLoggTag= 'KASC_RG_LOGG_SCALE_2'
@@ -64,23 +64,23 @@ if __name__ == '__main__':
                                                       isodist.FEH2Z(data['METALS'],zsolar=0.017),upper=True))#2.8)
     if False:
         rcclumplogg= clumplogg*(data['RC'] == 1)
-        print "%i / %i = %i%% APOKASC logg clump stars are in the RC catalog" % (numpy.sum(rcclumplogg),numpy.sum(clumplogg),float(numpy.sum(rcclumplogg))/numpy.sum(clumplogg)*100)
+        print("%i / %i = %i%% APOKASC logg clump stars are in the RC catalog" % (numpy.sum(rcclumplogg),numpy.sum(clumplogg),float(numpy.sum(rcclumplogg))/numpy.sum(clumplogg)*100))
         rcnoclumplogg= (True-clumplogg)*(data['RC'] == 1)
-        print "%i / %i = %i%% APOKASC logg non-clump stars are in the RC catalog" % (numpy.sum(rcnoclumplogg),numpy.sum(True-clumplogg),float(numpy.sum(rcnoclumplogg))/numpy.sum(True-clumplogg)*100.)
-        print "%i / %i = %i%% APOKASC logg non-clump stars out of all stars are in the RC catalog" % (numpy.sum(rcnoclumplogg),numpy.sum(data['RC'] == 1),float(numpy.sum(rcnoclumplogg))/numpy.sum(data['RC'] == 1)*100.)
+        print("%i / %i = %i%% APOKASC logg non-clump stars are in the RC catalog" % (numpy.sum(rcnoclumplogg),numpy.sum(True-clumplogg),float(numpy.sum(rcnoclumplogg))/numpy.sum(True-clumplogg)*100.))
+        print("%i / %i = %i%% APOKASC logg non-clump stars out of all stars are in the RC catalog" % (numpy.sum(rcnoclumplogg),numpy.sum(data['RC'] == 1),float(numpy.sum(rcnoclumplogg))/numpy.sum(data['RC'] == 1)*100.))
     bloggindx= (data['LOGG'] >= 1.8)*\
         (data['LOGG'] <= rcmodel.loggteffcut(data['TEFF'],data['METALS'],
                                              upper=True))
     gloggindx= (data[kascLoggTag] < 1.8)+\
         (data[kascLoggTag] > rcmodel.loggteffcut(data['TEFF'],data['METALS'],
                                                  upper=True))
-    print "Current contamination in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx),len(data),float(numpy.sum(bloggindx*gloggindx))*100./len(data))
+    print("Current contamination in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx),len(data),float(numpy.sum(bloggindx*gloggindx))*100./len(data)))
     nlogg= data[kascLoggTag]+numpy.random.normal(size=len(data))*0.2
     bloggindx= (nlogg >= 1.8)*(nlogg <= rcmodel.loggteffcut(data['TEFF'],
                                                             data['METALS'],
                                                             upper=True))
-    print "Future contamination w/ good logg (unbiased, errors 0.2) in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx),len(data),float(numpy.sum(bloggindx*gloggindx))*100./len(data))
-    print "Future contamination w/ good logg (unbiased, errors 0.2) for just RC in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx*rcindx),numpy.sum(rcindx),float(numpy.sum(bloggindx*gloggindx*rcindx))*100./numpy.sum(rcindx))
+    print("Future contamination w/ good logg (unbiased, errors 0.2) in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx),len(data),float(numpy.sum(bloggindx*gloggindx))*100./len(data)))
+    print("Future contamination w/ good logg (unbiased, errors 0.2) for just RC in logg range %i / % i = %i%%" % (numpy.sum(bloggindx*gloggindx*rcindx),numpy.sum(rcindx),float(numpy.sum(bloggindx*gloggindx*rcindx))*100./numpy.sum(rcindx)))
     #Select stars to be in the RC from the APOKASC data, then check against 
     #evolutionary state
     jk= data['J0']-data['K0']
@@ -99,7 +99,7 @@ if __name__ == '__main__':
     seismo= True-((rcseismoState == 'UNKNOWN')+(rcseismoState == '-9999'))
     norcseismo= (rcseismoState == 'RGB') \
         + (rcseismoState == 'DWARF/SUBGIANT')
-    print "%i / %i = %i%% APOKASC non-CLUMP stars out of all RC stars would be included with good logg" % (numpy.sum(norcseismo),numpy.sum(seismo),float(numpy.sum(norcseismo))/numpy.sum(seismo)*100.)
+    print("%i / %i = %i%% APOKASC non-CLUMP stars out of all RC stars would be included with good logg" % (numpy.sum(norcseismo),numpy.sum(seismo),float(numpy.sum(norcseismo))/numpy.sum(seismo)*100.))
     #Now, how many of the stars in our RC cut have evol and how many of RGB?
     indx= (jk < 0.8)*(jk >= 0.5)\
         *(logg >= 1.8)\
@@ -108,13 +108,13 @@ if __name__ == '__main__':
     rckascdata= data[indx]
     rcseismoState= numpy.char.strip(rckascdata[seismoStateTag])
     seismo= True-((rcseismoState == 'UNKNOWN')+(rcseismoState == '-9999'))
-    print "%i / %i = %i%% RC stars based on logg,teff,feh cut have seismo measurements" % (numpy.sum(seismo),len(rckascdata),float(numpy.sum(seismo))/len(rckascdata)*100.)
+    print("%i / %i = %i%% RC stars based on logg,teff,feh cut have seismo measurements" % (numpy.sum(seismo),len(rckascdata),float(numpy.sum(seismo))/len(rckascdata)*100.))
     indx= (jk < 0.8)*(jk >= 0.5)\
         *(logg > rcmodel.loggteffcut(data['TEFF'],z,upper=True))
     norckascdata= data[indx]
     norcseismoState= numpy.char.strip(norckascdata[seismoStateTag])
     seismo= True-((norcseismoState == 'UNKNOWN')+(norcseismoState == '-9999'))
-    print "%i / %i = %i%% RGB stars based on logg,teff,feh cut have seismo measurements" % (numpy.sum(seismo),len(norckascdata),float(numpy.sum(seismo))*100./len(norckascdata))
+    print("%i / %i = %i%% RGB stars based on logg,teff,feh cut have seismo measurements" % (numpy.sum(seismo),len(norckascdata),float(numpy.sum(seismo))*100./len(norckascdata)))
     #Select stars to be in the RC from the APOKASC data, using the selection criteria of Williams et al. then check against 
     #evolutionary state
     jk= data['J0']-data['K0']
@@ -129,7 +129,7 @@ if __name__ == '__main__':
     seismo= True-((rcseismoState == 'UNKNOWN')+(rcseismoState == '-9999'))
     norcseismo= (rcseismoState == 'RGB') \
         + (rcseismoState == 'DWARF/SUBGIANT')
-    print "%i / %i = %i%% APOKASC non-CLUMP stars out of all RC stars would be included with good logg for the Williams et al. selection" % (numpy.sum(norcseismo),numpy.sum(seismo),float(numpy.sum(norcseismo))/numpy.sum(seismo)*100.)
+    print("%i / %i = %i%% APOKASC non-CLUMP stars out of all RC stars would be included with good logg for the Williams et al. selection" % (numpy.sum(norcseismo),numpy.sum(seismo),float(numpy.sum(norcseismo))/numpy.sum(seismo)*100.))
 
 """Some similar clump and no clump stars:
 Teff= 4723, metallicity ~0.05

--- a/apogee/samples/make_rcsample.py
+++ b/apogee/samples/make_rcsample.py
@@ -36,7 +36,7 @@ def make_rcsample(parser):
         #Create savefilename if not given
         savefilename= os.path.join(appath._APOGEE_DATA,
                                    'rcsample_'+appath._APOGEE_REDUX+'.fits')
-        print "Saving to %s ..." % savefilename
+        print("Saving to %s ..." % savefilename)
     #Read the base-sample
     data= apread.allStar(adddist=_ADDHAYDENDIST,rmdups=options.rmdups)
     #Remove a bunch of fields that we do not want to keep
@@ -128,7 +128,7 @@ def make_rcsample(parser):
     data['ADDL_LOGG_CUT']= ((data['TEFF']-4800.)/1000.+2.75) > data['LOGG']
     if options.loggcut:
         data= data[data['ADDL_LOGG_CUT'] == 1]
-    print "Making catalog of %i objects ..." % len(data)
+    print("Making catalog of %i objects ..." % len(data))
     #Add distances
     data= esutil.numpy_util.add_fields(data,[('RC_DIST', float),
                                              ('RC_DM', float),

--- a/apogee/select/apogeeSelect.py
+++ b/apogee/select/apogeeSelect.py
@@ -395,7 +395,7 @@ class apogeeSelect:
             indx= visits == avisit
             if numpy.sum(indx) == 0.:
                 #Hasn't happened so far
-                print "Warning: no visit in combined spectrum found for data point %s" % specdata['APSTAR_ID'][ii]            
+                print("Warning: no visit in combined spectrum found for data point %s" % specdata['APSTAR_ID'][ii]            )
                 avisit= specdata['ALL_VISITS'][ii].split(',')[0].strip() #this is a visit ID
                 indx= visits == avisit
             avisitsplate= int(allVisit['PLATE'][indx][0])
@@ -418,7 +418,7 @@ class apogeeSelect:
             else:
                 tcohort= '???'
                 plateIncomplete+= 1
-#                print "Warning: cohort undetermined: H = %f" % specdata['H'][ii], avisitsDesign['SHORT_COHORT_MIN_H'], avisitsDesign['SHORT_COHORT_MAX_H'], avisitsDesign['MEDIUM_COHORT_MIN_H'], avisitsDesign['MEDIUM_COHORT_MAX_H'], avisitsDesign['LONG_COHORT_MIN_H'], avisitsDesign['LONG_COHORT_MAX_H'], avisitsplate
+#                print("Warning: cohort undetermined: H = %f" % specdata['H'][ii], avisitsDesign['SHORT_COHORT_MIN_H'], avisitsDesign['SHORT_COHORT_MAX_H'], avisitsDesign['MEDIUM_COHORT_MIN_H'], avisitsDesign['MEDIUM_COHORT_MAX_H'], avisitsDesign['LONG_COHORT_MIN_H'], avisitsDesign['LONG_COHORT_MAX_H'], avisitsplate)
             locIndx= specdata['LOCATION_ID'][ii] == self._locations
             if cohortnum > 0 and tcohort != '???' and \
                     ((tcohort == 'short' and self._short_completion[locIndx,cohortnum-1] >= self._frac4complete) \
@@ -984,8 +984,8 @@ class apogeeSelect:
         """
         photr,specr,fn1,fn2= self._location_Hcdfs(location,cohort)
         if numpy.all(numpy.isnan(photr)):
-            print "Location %i has no spectroscopic data in the statistical sample ..." % location
-            print "Returning ..."
+            print("Location %i has no spectroscopic data in the statistical sample ..." % location)
+            print("Returning ...")
             return None           
         if xrange is None: xrange= [numpy.amin([numpy.amin(photr),numpy.amin(specr)])-0.1,
                                     numpy.amax([numpy.amax(photr),numpy.amax(specr)])+0.1]
@@ -1117,7 +1117,7 @@ class apogeeSelect:
                 indx=(jko >= 0.5)*(jko < 0.8)
             else:
                 indx= jko >= 0.5
-            #print field_name, numpy.log10(len(tapogeeObject)), numpy.log10(numpy.sum(indx))
+            #print(field_name, numpy.log10(len(tapogeeObject)), numpy.log10(numpy.sum(indx)))
             tapogeeObject= tapogeeObject[indx]
             #Cut to relevant magnitude range
             if numpy.nanmax(self._long_completion[ii,:]) >= self._frac4complete:
@@ -1135,10 +1135,10 @@ class apogeeSelect:
                 thmin= numpy.nanmin(self._short_cohorts_hmin[ii,:])
             else: #this avoids a warning
                 thmin= numpy.nan
-            #print numpy.nanmax(self._long_completion[ii,:]), numpy.nanmax(self._medium_completion[ii,:]), numpy.nanmax(self._short_completion[ii,:]), thmin, thmax
+            #print(numpy.nanmax(self._long_completion[ii,:]), numpy.nanmax(self._medium_completion[ii,:]), numpy.nanmax(self._short_completion[ii,:]), thmin, thmax)
             indx= (tapogeeObject['H'] >= thmin)\
                 *(tapogeeObject['H'] <= thmax)
-            #print numpy.log10(len(tapogeeObject)), numpy.log10(numpy.sum(indx))
+            #print(numpy.log10(len(tapogeeObject)), numpy.log10(numpy.sum(indx)))
             tapogeeObject= tapogeeObject[indx]
             photdata['%i' % self._locations[ii]]= tapogeeObject
         sys.stdout.write('\r'+_ERASESTR+'\r')

--- a/apogee/test/test_windows.py
+++ b/apogee/test/test_windows.py
@@ -66,7 +66,7 @@ def test_windows(options):
             elemPath= apwindow.path(elem,dr=options.dr)
             if not os.path.exists(elemPath): continue
             # Simulate deltaAbu up and down
-            print "Working on %s" % (elem.capitalize())
+            print("Working on %s" % (elem.capitalize()))
             abu= [atomic_number(elem),-options.deltaAbu,options.deltaAbu]
             if options.moog:
                 synspec= \

--- a/apogee/tools/__init__.py
+++ b/apogee/tools/__init__.py
@@ -1,8 +1,8 @@
 import os.path
 import numpy
 from scipy import optimize
-import path as appath
-import download as download
+from . import path as appath
+from . import download as download
 import fitsio
 from periodictable import elements
 try:

--- a/apogee/tools/__init__.py
+++ b/apogee/tools/__init__.py
@@ -15,8 +15,8 @@ except ValueError:
     _INDEX_ARRAYS_LOADED= False
 else:
     _INDEX_ARRAYS_LOADED= True
-    _PARAM_SYMBOL= [index.strip().lower() for index in indexArrays['PARAM_SYMBOL'].flatten()]
-    _ELEM_SYMBOL= [index.strip().lower() for index in indexArrays['ELEM_SYMBOL'].flatten()]
+    _PARAM_SYMBOL= [index.strip().lower().decode("utf-8")  for index in indexArrays['PARAM_SYMBOL'].flatten()]
+    _ELEM_SYMBOL= [index.strip().lower().decode("utf-8")  for index in indexArrays['ELEM_SYMBOL'].flatten()]
     _ELEM_NUMBER_DICT= dict((elem,
                              elements.__dict__[elem.capitalize()].number)
                             for elem in _ELEM_SYMBOL 
@@ -40,7 +40,7 @@ def paramIndx(param):
     if param.lower() == 'alpha': return _PARAM_SYMBOL.index('o mg si s ca ti')
     else: 
         try:
-            return _PARAM_SYMBOL.index(param.lower())
+            return _PARAM_SYMBOL.index(param.lower().decode("utf-8"))
         except ValueError:
             raise KeyError("Stellar parameter %s not recognized" % param)
 
@@ -59,7 +59,7 @@ def elemIndx(elem):
     """
     if not _INDEX_ARRAYS_LOADED: raise ImportError("elemIndx function cannot be used, because the allStar file could not be properly loaded")
     try:
-        return _ELEM_SYMBOL.index(elem.lower())
+        return _ELEM_SYMBOL.index(elem.lower().decode("utf-8"))
     except ValueError:
         raise KeyError("Element %s is not part of the APOGEE elements (can't do everything!) or something went wrong)" % elem)
 

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,10 @@ setup(name='apogee',
                     'apogee/modelspec':['scripts/makemoogmodel.awk'],},
       dependency_links = ['https://github.com/jobovy/galpy/tarball/master#egg=galpy',
                           'https://github.com/jobovy/isodist/tarball/master#egg=isodist'],
+#      install_requires=['numpy','scipy','matplotlib',
+#                        'fitsio','esutil','galpy',
+#                        'isodist','periodictable','tqdm']
       install_requires=['numpy','scipy','matplotlib',
-                        'fitsio','esutil','galpy',
+                        'fitsio','galpy',
                         'isodist','periodictable','tqdm']
       )

--- a/setup.py
+++ b/setup.py
@@ -53,9 +53,11 @@ if _INSTALL_FERRE:
 
 if _INSTALL_FERRE:
     # Download the code
-    _FERRE_FILE= 'ferre_4.5.6.tar.gz'
-    _FERRE_URL= 'http://leda.as.utexas.edu/ferre/%s' % _FERRE_FILE
-    print '\033[1m'+"Downloading and installing FERRE from %s ..." % _FERRE_URL +'\033[0m'
+    #_FERRE_FILE= 'ferre_4.5.6.tar.gz'
+    _FERRE_FILE= 'ferre_4.6.6.tar.gz'
+    #_FERRE_URL= 'http://leda.as.utexas.edu/ferre/%s' % _FERRE_FILE
+    _FERRE_URL= 'http://www.as.utexas.edu/~hebe/ferre/%s' % _FERRE_FILE
+    print('\033[1m'+"Downloading and installing FERRE from %s ..." % _FERRE_URL +'\033[0m')
     # Create temporary directory
     tmpdir= tempfile.mkdtemp(dir='./')
     os.mkdir(os.path.join(tmpdir,'ferre'))
@@ -63,13 +65,13 @@ if _INSTALL_FERRE:
         subprocess.check_call(['wget',_FERRE_URL,'-O',
                                os.path.join(tmpdir,'ferre',_FERRE_FILE)])
     except subprocess.CalledProcessError:
-        print '\033[1m'+"Downloading FERRE from %s failed ..." % _FERRE_URL +'\033[0m'
+        print('\033[1m'+"Downloading FERRE from %s failed ..." % _FERRE_URL +'\033[0m')
     # Unpack and install
     os.chdir(os.path.join(tmpdir,'ferre'))
     try:
         subprocess.check_call(['tar','xvzf',_FERRE_FILE])
     except subprocess.CalledProcessError:
-        print '\033[1m'+"Untarring/gunzipping FERRE failed ..." % _FERRE_URL +'\033[0m'
+        print('\033[1m'+"Untarring/gunzipping FERRE failed ..." % _FERRE_URL +'\033[0m')
     os.chdir('src')
     # Change flen in share.f90
     with open("tmp.f90", "w") as fout:
@@ -90,7 +92,7 @@ if _INSTALL_FERRE:
         else:
             subprocess.check_call(['make'])
     except subprocess.CalledProcessError:
-        print '\033[1m'+"Compiling FERRE failed ..." % _FERRE_URL +'\033[0m'
+        print('\033[1m'+"Compiling FERRE failed ..." % _FERRE_URL +'\033[0m')
     os.rename('a.out','../../../ferre')
     os.rename('ascii2bin','../../../ascii2bin')
     # Remove everything
@@ -98,7 +100,7 @@ if _INSTALL_FERRE:
     try:
         subprocess.check_call(['rm','-rf',tmpdir])
     except subprocess.CalledProcessError:
-        print '\033[1m'+"Removing FERRE temporary files failed ..." % _FERRE_URL +'\033[0m'
+        print('\033[1m'+"Removing FERRE temporary files failed ..." % _FERRE_URL +'\033[0m')
     shutil.copy('ferre',get_setuptools_script_dir())
     shutil.copy('ascii2bin',get_setuptools_script_dir())
 

--- a/setup.py
+++ b/setup.py
@@ -127,10 +127,12 @@ setup(name='apogee',
                     'apogee/modelspec':['scripts/makemoogmodel.awk'],},
       dependency_links = ['https://github.com/jobovy/galpy/tarball/master#egg=galpy',
                           'https://github.com/jobovy/isodist/tarball/master#egg=isodist'],
-#      install_requires=['numpy','scipy','matplotlib',
-#                        'fitsio','esutil','galpy',
-#                        'isodist','periodictable','tqdm']
+#     NOTE: esutil is not python3 compatible and install will fail
       install_requires=['numpy','scipy','matplotlib',
-                        'fitsio','galpy',
+                        'fitsio','esutil','galpy',
                         'isodist','periodictable','tqdm']
+#      OPTION TO INSTALL WITHOUT esutil (functionality of apogee will be limited)
+#      install_requires=['numpy','scipy','matplotlib',
+#                        'fitsio','galpy',
+#                        'isodist','periodictable','tqdm']
       )


### PR DESCRIPTION
This makes apogee nearly compatible with python3, except for the esutil dependency. esutil has a problem with how some of its underlying C code talks to numpy arrays, so I pretended it isn't required in order to get apogee to install. It is still not usable, however, because `import apogee.tools.read as apread` lets me get as far as an esutil ImportError. I also updated the ferre URLs.