### PR TITLE
Changed parsing of ESUTIL version to account for release candidates

### DIFF
--- a/apogee/tools/read.py
+++ b/apogee/tools/read.py
@@ -24,7 +24,7 @@ import numpy
 try:
     import esutil
     _ESUTIL_LOADED= True
-    _ESUTIL_VERSION= [int(v.translate(None, 'rc')) for v in esutil.__version__.split('.')]
+    _ESUTIL_VERSION= [int(v[0]) for v in esutil.__version__.split('.')]
 except ImportError:
     _ESUTIL_LOADED= False
 import fitsio

--- a/apogee/tools/read.py
+++ b/apogee/tools/read.py
@@ -24,7 +24,7 @@ import numpy
 try:
     import esutil
     _ESUTIL_LOADED= True
-    _ESUTIL_VERSION= [int(v) for v in esutil.__version__.split('.')]
+    _ESUTIL_VERSION= [int(v.translate(None, 'rc')) for v in esutil.__version__.split('.')]
 except ImportError:
     _ESUTIL_LOADED= False
 import fitsio


### PR DESCRIPTION
Hi Jo,

This is super small. For another reason, I needed to compile the master branch of esutil. It's version is '0.6.2rc2' which gave an exception when trying to int('2rc2'). I looked at the code and realized that the second number (here, '6') was the one you were interested in, so I used the built-in translate to remove  'rc' from the string. Now, 
_ESUTIL_VERSION = [0, 6, 22]  for my esutil version. The code runs as it should.

Cheers,
Jon