### PR TITLE
Fixes for astroNN

### DIFF
--- a/apogee/tools/download.py
+++ b/apogee/tools/download.py
@@ -168,16 +168,20 @@ def astroNNDistances(dr=None):
        (none; just downloads)
     HISTORY:
        2018-02-15 - Written - Bovy (UofT)
+       2022-03-23 - Edited for dr>14 - Hopkins (Oxford)
     """
     if dr is None: dr= path._default_dr()
-    # First make sure the file doesn't exist
-    filePath= path.astroNNDistancesPath(dr=dr)
-    if os.path.exists(filePath): return None
-    # Create the file path
-    downloadPath= 'https://github.com/henrysky/astroNN_gaia_dr2_paper/raw/'\
-        'master/apogee_dr14_nn_dist.fits'
-    _download_file(downloadPath,filePath,dr,verbose=True)
-    return None
+    if int(dr) == 14:
+        # First make sure the file doesn't exist
+        filePath= path.astroNNDistancesPath(dr=dr)
+        if os.path.exists(filePath): return None
+        # Create the file path
+        downloadPath= 'https://github.com/henrysky/astroNN_gaia_dr2_paper/raw/'\
+            'master/apogee_dr14_nn_dist.fits'
+        _download_file(downloadPath,filePath,dr,verbose=True)
+        return None
+    else: # From DR16 onwards, one astroNN file
+        return astroNN(dr=dr)
 
 def astroNNAges(dr=None):
     """
@@ -191,16 +195,20 @@ def astroNNAges(dr=None):
        (none; just downloads)
     HISTORY:
        2018-02-16 - Written - Bovy (UofT)
+       2022-03-23 - Edited for dr>14 - Hopkins (Oxford)
     """
     if dr is None: dr= path._default_dr()
-    # First make sure the file doesn't exist
-    filePath= path.astroNNAgesPath(dr=dr)
-    if os.path.exists(filePath): return None
-    # Create the file path
-    downloadPath= 'http://www.astro.ljmu.ac.uk/~astjmack/APOGEEGaiaAges/'\
-                  'astroNNBayes_ages_goodDR14.fits'
-    _download_file(downloadPath,filePath,dr,verbose=True)
-    return None
+    if int(dr) == 14:
+        # First make sure the file doesn't exist
+        filePath= path.astroNNAgesPath(dr=dr)
+        if os.path.exists(filePath): return None
+        # Create the file path
+        downloadPath= 'http://www.astro.ljmu.ac.uk/~astjmack/APOGEEGaiaAges/'\
+                      'astroNNBayes_ages_goodDR14.fits'
+        _download_file(downloadPath,filePath,dr,verbose=True)
+        return None
+    else: # From DR16 onwards, one astroNN file
+        return astroNN(dr=dr)
 
 def aspcapStar(loc_id,apogee_id,telescope='apo25m',dr=None):
     """

--- a/apogee/tools/read.py
+++ b/apogee/tools/read.py
@@ -1417,10 +1417,7 @@ def _add_astroNN_orbits(data,astroNNOrbitsdata):
                             'omega_r','omega_r_err','omega_phi','omega_phi_err',
                             'omega_z','omega_z_err','theta_r','theta_r_err',
                             'theta_phi','theta_phi_err','theta_z','theta_z_err',
-                            'rl','rl_err','Energy','Energy_Err','EminusEc','EminusEc_err']
-        if int(dr) == 17:
-            fields_to_append.remove('Energy_Err')
-            fields_to_append.append('Energy_err')
+                            'rl','rl_err','Energy','Energy_err','EminusEc','EminusEc_err']
     if True:
         # Faster way to join structured arrays (see https://stackoverflow.com/questions/5355744/numpy-joining-structured-arrays)
         newdtype= data.dtype.descr+\


### PR DESCRIPTION
`download.astroNNDistances` and `download.astroNNAges` previously only downloaded DR14 distance and age files, regardless of `dr` argument, causing incorrect file to be saved as the combined astroNN file for DR16 and DR17. Now fixed so `download.astroNN` is called for DR16 and DR17, downloading correct combined astroNN file.

Judging by previous code in `read._add_astroNN_orbits`, the DR16 astroNN FITS file used to have a field `Energy_Err`, however in most up-to-date version (v1) this field has been changed to `Energy_err` to match DR17. Now fixed so `fields_to_append` is the same for both DR16 and DR17. N.B. this bug only affects users with `fitsio` installed, as with `fitsio` FITS fields are case-sensitive whereas with `astropy.io.fits` they are not.